### PR TITLE
Adds ability to specify carousel-slide attributes on existing slide elements instead of wrapping them in <carousel-slide>

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example, the following code implements the most simple configuration for the
 </simple-carousel>
 ```
 
-It can also be configured with attributes:
+You can also use attributes (with or without the `data-` prefix):
 
 ```html
 <simple-carousel>
@@ -29,7 +29,7 @@ It can also be configured with attributes:
   <div carousel-slide>
     <h3>2</h3>
   </div>
-  <div carousel-slide>
+  <div data-carousel-slide>
     <h3>3</h3>
   </div>         
 </simple-carousel>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ For example, the following code implements the most simple configuration for the
 </simple-carousel>
 ```
 
+It can also be configured with attributes:
+
+```html
+<simple-carousel>
+  <div carousel-slide>
+    <h3>1</h3>
+  </div>
+  <div carousel-slide>
+    <h3>2</h3>
+  </div>
+  <div carousel-slide>
+    <h3>3</h3>
+  </div>         
+</simple-carousel>
+```
+
 ## Demo
 
 

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -54,6 +54,10 @@ Simple carousel component for Polymer 1.0
         font-weight: bold;
         cursor: pointer;
         opacity: 0.7;
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
       }
 
       button:hover,

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -21,7 +21,8 @@ Simple carousel component for Polymer 1.0
       }
 
       :host ::content carousel-slide,
-      :host ::content [carousel-slide] {
+      :host ::content [carousel-slide],
+      :host ::content [data-carousel-slide] {
         position:absolute;
         width:100%;
         left:0;
@@ -29,12 +30,14 @@ Simple carousel component for Polymer 1.0
       }
 
       :host ::content carousel-slide:first-child,
-      :host ::content [carousel-slide]:first-child {
+      :host ::content [carousel-slide]:first-child,
+      :host ::content [data-carousel-slide]:first-child {
           position:relative;
       }
 
       :host ::content carousel-slide:not([selected]),
-      :host ::content [carousel-slide]:not([selected]) {
+      :host ::content [carousel-slide]:not([selected]),
+      :host ::content [data-carousel-slide]:not([selected]) {
         display:none;
       }
 
@@ -74,7 +77,7 @@ Simple carousel component for Polymer 1.0
     </style>
 
     <div>
-      <content select="carousel-slide, [carousel-slide]"></content>
+      <content select="carousel-slide, [carousel-slide], [data-carousel-slide]"></content>
     </div>
 
     <button id="prevBtn" on-click="previous">❮</button>
@@ -155,7 +158,7 @@ Simple carousel component for Polymer 1.0
         }
       },
       attached: function() {
-        this.selected = this.queryEffectiveChildren('carousel-slide, [carousel-slide]');
+        this.selected = this.queryEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
         //this.queryEffectiveChildren('carousel-slide').setAttribute('selected', '');
       },
       _selectedChanged: function(selected, oldSelected) {
@@ -175,7 +178,7 @@ Simple carousel component for Polymer 1.0
         var elem = this.selected.previousElementSibling;
         this._autoStart();
         if(this.infiniteLoop && !elem){
-          var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide]');
+          var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
           elem = elems[elems.length - 1];
         }
 
@@ -189,7 +192,7 @@ Simple carousel component for Polymer 1.0
         var elem = this.selected.nextElementSibling;
         this._autoStart();
         if(this.infiniteLoop && !elem){
-          elem = this.queryEffectiveChildren('carousel-slide, [carousel-slide]');
+          elem = this.queryEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
         }
 
         elem && this._translateAnimation(elem,1);

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -20,18 +20,21 @@ Simple carousel component for Polymer 1.0
         overflow:hidden;
       }
 
-      :host ::content carousel-slide{
+      :host ::content carousel-slide,
+      :host ::content [carousel-slide] {
         position:absolute;
         width:100%;
         left:0;
         top:0;
       }
 
-      :host ::content carousel-slide:first-child{
+      :host ::content carousel-slide:first-child,
+      :host ::content [carousel-slide]:first-child {
           position:relative;
       }
 
-      :host ::content carousel-slide:not([selected]) {
+      :host ::content carousel-slide:not([selected]),
+      :host ::content [carousel-slide]:not([selected]) {
         display:none;
       }
 
@@ -71,7 +74,7 @@ Simple carousel component for Polymer 1.0
     </style>
 
     <div>
-      <content select="carousel-slide"></content>
+      <content select="carousel-slide, [carousel-slide]"></content>
     </div>
 
     <button id="prevBtn" on-click="previous">❮</button>
@@ -152,7 +155,7 @@ Simple carousel component for Polymer 1.0
         }
       },
       attached: function() {
-        this.selected = this.queryEffectiveChildren('carousel-slide');
+        this.selected = this.queryEffectiveChildren('carousel-slide, [carousel-slide]');
         //this.queryEffectiveChildren('carousel-slide').setAttribute('selected', '');
       },
       _selectedChanged: function(selected, oldSelected) {
@@ -172,7 +175,7 @@ Simple carousel component for Polymer 1.0
         var elem = this.selected.previousElementSibling;
         this._autoStart();
         if(this.infiniteLoop && !elem){
-          var elems = this.queryAllEffectiveChildren('carousel-slide');
+          var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide]');
           elem = elems[elems.length - 1];
         }
 
@@ -186,7 +189,7 @@ Simple carousel component for Polymer 1.0
         var elem = this.selected.nextElementSibling;
         this._autoStart();
         if(this.infiniteLoop && !elem){
-          elem = this.queryEffectiveChildren('carousel-slide');
+          elem = this.queryEffectiveChildren('carousel-slide, [carousel-slide]');
         }
 
         elem && this._translateAnimation(elem,1);

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../../src/shared-styles/shared-styles.html" />
 <link rel="import" href="carousel-slide.html">
 <link rel="import" href="animation-behavior.html">
 
@@ -12,7 +13,7 @@ Simple carousel component for Polymer 1.0
 
 <dom-module id="simple-carousel">
   <template>
-    <style>
+    <style include="shared-styles">
 
       :host {
         display: block;
@@ -73,15 +74,17 @@ Simple carousel component for Polymer 1.0
         cursor: default;
       }
 
-
+      :host(.non-keyboard) :focus {
+        outline: none !important;
+      }
     </style>
 
     <div>
       <content select="carousel-slide, [carousel-slide], [data-carousel-slide]"></content>
     </div>
 
-    <button id="prevBtn" on-click="previous">❮</button>
-    <button id="nextBtn" on-click="next">❯</button>
+    <button id="prevBtn" on-click="previous" on-keyup="keyboardAdvancePrevious" tabindex="0">❮</button>
+    <button id="nextBtn" on-click="next" on-keyup="keyboardAdvanceNext" tabindex="0">❯</button>
 
 
   </template>
@@ -171,10 +174,34 @@ Simple carousel component for Polymer 1.0
           }
 
       },
+      keyboardAdvancePrevious: function ( event ) {
+        if ( ( event.which === 32 ) || ( event.which === 13 ) ) {
+          this.previous( event );
+        }
+      },
+      keyboardAdvanceNext: function ( event ) {
+        if ( ( event.which === 32 ) || ( event.which === 13 ) ) {          
+          this.next( event );
+        }
+      },
+
       /**
        * Shows the previous carousel element.
        */
-      previous: function(){
+      previous: function( event ){
+        var host = Polymer.dom( this );
+        console.log( 'host', host );
+
+        if (
+          ( event.type === 'keyup' )
+          || ( event.type === 'keydown' )
+          || ( event.type === 'keypress' )
+        ) {
+          host.classList.remove( 'non-keyboard' );
+        } else {
+          host.classList.add( 'non-keyboard' );
+        }
+
         var elem = this.selected.previousElementSibling;
         this._autoStart();
         if(this.infiniteLoop && !elem){
@@ -188,7 +215,20 @@ Simple carousel component for Polymer 1.0
       /**
        * Shows the next carousel element.
        */
-      next:function(){
+      next:function( event ){
+        var host = Polymer.dom( this );
+        console.log( 'host', host );
+
+        if (
+          ( event.type === 'keyup' )
+          || ( event.type === 'keydown' )
+          || ( event.type === 'keypress' )
+        ) {
+          host.classList.remove( 'non-keyboard' );
+        } else {
+          host.classList.add( 'non-keyboard' );
+        }
+
         var elem = this.selected.nextElementSibling;
         this._autoStart();
         if(this.infiniteLoop && !elem){


### PR DESCRIPTION
Ran into this issue where I wanted to add carousel behavior to an existing HTML hierarchy, rather than modify it. Introducing `<carousel-slide>`s as wrappers to elements that I was already calling `<og-portfolio__slide>` seemed redundant to me:

```html
<simple-carousel>
  <carousel-slide>
    <og-portfolio__slide>foo</og-portfolio__slide>
  </carousel-slide>
  <carousel-slide>
    <og-portfolio__slide>bar</og-portfolio__slide>
  </carousel-slide>
</simple-carousel>
```

So I tweaked the code, in order to do this instead:

```html
<simple-carousel>
  <og-portfolio__slide carousel-slide>foo</og-portfolio__slide>
  <og-portfolio__slide carousel-slide>bar</og-portfolio__slide>
</simple-carousel>
```