### PR TITLE
Fixing prev, next function and some cleanup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-carousel",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Simple carousel component for Polymer 1.0",
   "authors": [
     "franjsc"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-carousel",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Simple carousel component for Polymer 1.0",
   "authors": [
     "franjsc"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-carousel",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Simple carousel component for Polymer 1.0",
   "authors": [
     "franjsc"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-carousel",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "Simple carousel component for Polymer 1.0",
   "authors": [
     "franjsc"

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -163,8 +163,28 @@ Simple carousel component for Polymer 1.0
           this.intervalHander = setInterval(function(){that.next()}, this.transitionTime);
         }
       },
+      _getNextVisibleSlide() {
+        var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
+        var selected;
+        elems.forEach(function(elem) {
+          if (!elem.hidden && !selected) {
+            selected = elem;
+          }
+        });
+        return selected;
+      },
+      _getPreviousVisibleSlide() {
+        var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
+        var n = 1;
+        elem = elems[elems.length - n];
+        while (elem.hidden) {
+          n++;
+          elem = elems[elems.length - n];
+        }
+        return elem;
+      },
       attached: function() {
-        this.selected = this.queryEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
+        this.selected = this._getNextVisibleSlide();
       },
       _selectedChanged: function(selected, oldSelected) {
           if (oldSelected) oldSelected.removeAttribute('selected');
@@ -181,7 +201,7 @@ Simple carousel component for Polymer 1.0
        */
       _setKeyboardClass: function(event) {
         var host = Polymer.dom(this);
-        if (event.type === 'keyup' || event.type === 'keydown' || event.type === 'keypress') {
+        if (event && (event.type === 'keyup' || event.type === 'keydown' || event.type === 'keypress')) {
           host.classList.remove('non-keyboard');
         } else {
           host.classList.add('non-keyboard');
@@ -208,13 +228,7 @@ Simple carousel component for Polymer 1.0
         var elem = isSlideElem ? this.selected.previousElementSibling : null;
         this._autoStart();
         if(this.infiniteLoop && !elem){
-          var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
-          var n = 1;
-          elem = elems[elems.length - n];
-          while (elem.hidden) {
-            n++;
-            elem = elems[elems.length - n];
-          }
+          elem = this._getPreviousVisibleSlide();
         }
 
         elem && this._translateAnimation(elem,-1);
@@ -230,7 +244,7 @@ Simple carousel component for Polymer 1.0
         var elem = isSlideElem ? this.selected.nextElementSibling : null;
         this._autoStart();
         if(this.infiniteLoop && !elem){
-          elem = this.queryEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
+          elem = this._getNextVisibleSlide();
         }
 
         elem && this._translateAnimation(elem,1);

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -180,7 +180,7 @@ Simple carousel component for Polymer 1.0
       /**
        * Sets keyboard class based on event type
        */
-      _setKeyboardClass: function() {
+      _setKeyboardClass: function(event) {
         var host = Polymer.dom(this);
         if (event.type === 'keyup' || event.type === 'keydown' || event.type === 'keypress') {
           host.classList.remove('non-keyboard');
@@ -203,14 +203,19 @@ Simple carousel component for Polymer 1.0
        * Shows the previous carousel element.
        */
       previous: function(event) {
-        this._setKeyboardClass();
+        this._setKeyboardClass(event);
         var prevElem = this.selected.previousElementSibling;
-        var isSlideElem = prevElem && prevElem.tagName === 'CAROUSEL-SLIDE';
+        var isSlideElem = prevElem && prevElem.tagName === 'CAROUSEL-SLIDE' && !prevElem.hidden;
         var elem = isSlideElem ? this.selected.previousElementSibling : null;
         this._autoStart();
         if(this.infiniteLoop && !elem){
           var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
-          elem = elems[elems.length - 1];
+          var n = 1;
+          elem = elems[elems.length - n];
+          while (elem.hidden) {
+            n++;
+            elem = elems[elems.length - n];
+          }
         }
 
         elem && this._translateAnimation(elem,-1);
@@ -220,9 +225,9 @@ Simple carousel component for Polymer 1.0
        * Shows the next carousel element.
        */
       next:function(event) {
-        this._setKeyboardClass();
+        this._setKeyboardClass(event);
         var nextElem = this.selected.nextElementSibling;
-        var isSlideElem = nextElem && nextElem.tagName === 'CAROUSEL-SLIDE';
+        var isSlideElem = nextElem && nextElem.tagName === 'CAROUSEL-SLIDE' && !nextElem.hidden;
         var elem = isSlideElem ? this.selected.nextElementSibling : null;
         this._autoStart();
         if(this.infiniteLoop && !elem){

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../../src/shared-styles/shared-styles.html" />
 <link rel="import" href="carousel-slide.html">
 <link rel="import" href="animation-behavior.html">
 
@@ -13,7 +12,7 @@ Simple carousel component for Polymer 1.0
 
 <dom-module id="simple-carousel">
   <template>
-    <style include="shared-styles">
+    <style>
 
       :host {
         display: block;

--- a/simple-carousel.html
+++ b/simple-carousel.html
@@ -166,7 +166,6 @@ Simple carousel component for Polymer 1.0
       },
       attached: function() {
         this.selected = this.queryEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
-        //this.queryEffectiveChildren('carousel-slide').setAttribute('selected', '');
       },
       _selectedChanged: function(selected, oldSelected) {
           if (oldSelected) oldSelected.removeAttribute('selected');
@@ -178,35 +177,36 @@ Simple carousel component for Polymer 1.0
           }
 
       },
-      keyboardAdvancePrevious: function ( event ) {
-        if ( ( event.which === 32 ) || ( event.which === 13 ) ) {
-          this.previous( event );
+      /**
+       * Sets keyboard class based on event type
+       */
+      _setKeyboardClass: function() {
+        var host = Polymer.dom(this);
+        if (event.type === 'keyup' || event.type === 'keydown' || event.type === 'keypress') {
+          host.classList.remove('non-keyboard');
+        } else {
+          host.classList.add('non-keyboard');
         }
       },
-      keyboardAdvanceNext: function ( event ) {
-        if ( ( event.which === 32 ) || ( event.which === 13 ) ) {          
-          this.next( event );
+      keyboardAdvancePrevious: function (event) {
+        if (event.which === 32 || event.which === 13) {
+          this.previous(event);
+        }
+      },
+      keyboardAdvanceNext: function (event) {
+        if (event.which === 32 || event.which === 13) {
+          this.next(event);
         }
       },
 
       /**
        * Shows the previous carousel element.
        */
-      previous: function( event ){
-        var host = Polymer.dom( this );
-        console.log( 'host', host );
-
-        if (
-          ( event.type === 'keyup' )
-          || ( event.type === 'keydown' )
-          || ( event.type === 'keypress' )
-        ) {
-          host.classList.remove( 'non-keyboard' );
-        } else {
-          host.classList.add( 'non-keyboard' );
-        }
-
-        var elem = this.selected.previousElementSibling;
+      previous: function(event) {
+        this._setKeyboardClass();
+        var prevElem = this.selected.previousElementSibling;
+        var isSlideElem = prevElem && prevElem.tagName === 'CAROUSEL-SLIDE';
+        var elem = isSlideElem ? this.selected.previousElementSibling : null;
         this._autoStart();
         if(this.infiniteLoop && !elem){
           var elems = this.queryAllEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');
@@ -219,21 +219,11 @@ Simple carousel component for Polymer 1.0
       /**
        * Shows the next carousel element.
        */
-      next:function( event ){
-        var host = Polymer.dom( this );
-        console.log( 'host', host );
-
-        if (
-          ( event.type === 'keyup' )
-          || ( event.type === 'keydown' )
-          || ( event.type === 'keypress' )
-        ) {
-          host.classList.remove( 'non-keyboard' );
-        } else {
-          host.classList.add( 'non-keyboard' );
-        }
-
-        var elem = this.selected.nextElementSibling;
+      next:function(event) {
+        this._setKeyboardClass();
+        var nextElem = this.selected.nextElementSibling;
+        var isSlideElem = nextElem && nextElem.tagName === 'CAROUSEL-SLIDE';
+        var elem = isSlideElem ? this.selected.nextElementSibling : null;
         this._autoStart();
         if(this.infiniteLoop && !elem){
           elem = this.queryEffectiveChildren('carousel-slide, [carousel-slide], [data-carousel-slide]');


### PR DESCRIPTION
When you use dom-repeat to populate the carousel-slide, `<template>` tag was also considered as the nextElementSibling when you click on the next button. That is now fixed, I do a check to see if the nextElementSibling is carousel-slide, if not, I set it to null.

I also cleaned up some code, moved the keyboard class into its own function. Not sure about the bower version, you can update it if you want to.